### PR TITLE
Added a few features; fixed a bug

### DIFF
--- a/calculator.c
+++ b/calculator.c
@@ -110,7 +110,7 @@ token doFunc(token input, token function)
 	number result = num;
 
 	if(strcmp(function, "abs") == 0)
-		result = abs(num);
+		result = fabs(num);
 	else if(strcmp(function, "floor") == 0)
 		result = floor(num);
 	else if(strcmp(function, "ceil") == 0)


### PR DESCRIPTION
I made a few changes. First of all, there was a bug with the abs function where it would convert to an integer (so abs(-4.5) would give 4.0.) This was because you used the C abs function (which works with ints) instead of fabs, its double equivalent.
I also added asin, acos, and atan as synonyms for the arc functions, an exp function, and a command-line option to only display the result without '=' for shell scripting and stuff.
