### PR TITLE
Small change for portability purposes

### DIFF
--- a/calculator.c
+++ b/calculator.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h> // Temporary
-#include <unistd.h>
+#include <getopt.h>
 #include "stack.h"
 
 #define bool char


### PR DESCRIPTION
Hi, me again! :-)
I just realized unistd.h isn't on Windows, so I changed it to getopt.h, since getopt is all I needed from it.
