### PR TITLE
Some work on the memory handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
 CC = gcc
 CFLAGS = -c -Wall
 LFLAGS = -Wall
+LIBS = -lm
 
 calc: stack.o calculator.c
-	$(CC) $(LFLAGS) -o calc calculator.c stack.c
+	$(CC) $(LFLAGS) -o calc calculator.c stack.c $(LIBS)
+
+stack_test: stack.o stack_test.c
+	$(CC) $(LFLAGS) -o stack_test stack_test.c stack.c $(LIBS)
 
 stack.o: stack.c stack.h
-	$(CC) $(CFLAGS) stack.c
+	$(CC) $(CFLAGS) stack.c $(LIBS)
 
 clean:
-	rm -f *.o calc
+	rm -f *.o calc stack_test
+
+.PHONY: calc

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ This is a command-line calculator, written in C, supporting the standard mathema
 *	`max(...)` Maximum
 *	`sum(...)` Summation
 *	`mean(...)` Mean
+*	`avg(...)` Mean
 *	`median(...)` Median
+*	`var(...)` Variance
 
 ## Why
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ This is a command-line calculator, written in C, supporting the standard mathema
 *	`cbrt(...)` Cube root
 *	`log(...)` Logarithm
 *	`exp(...)` Exponentiation (e^x)
+*	`min(...)` Minimum
+*	`max(...)` Maximum
+*	`sum(...)` Summation
+*	`mean(...)` Mean
+*	`median(...)` Median
 
 ## Why
 
@@ -51,10 +56,13 @@ Try typing `set display tokens on` and entering an expression. The calculator wi
 	* `display` Settings to do with the display of the evaluation process
 		* `postfix (off/on)` Display the postfix stack before evaluation
 		* `tokens (off/on)` Display the result of tokenization
-	* `mode (radians/degrees)` Evaluation mode of trigonometric functions 
+	* `mode (radians/degrees)` Evaluation mode of trigonometric functions
+	* `precision (X/auto)` Set precision to `X` decimal places or `auto` to reduce decimal places as far as possible without loosing precision. Default is 5 decimal places
 
 ## Building and Running
 
 Build with `make`. Clean with `make clean`. Run with `./calc`. Type any mathematical expression, for example, `3*(2^4) - 3*floor(2 * sin(3.14 / 2))` and press the Enter key. Type `quit` to close.
 
 There is a `-r` command line option which removes the `=` from the output, outputting only the result value. This is designed for use in situations such as shell scripting, where only the raw, unprocessed value is desired.
+
+There is a `-m` command line option which sets the maximal length of a token. Default is 512 characters.

--- a/stack.c
+++ b/stack.c
@@ -5,7 +5,7 @@
 void stackInit(Stack *s, int size)
 {
 	s->content = malloc(size * sizeof(void*));
-	s->size = 0;
+	s->size = size;
 	s->top = -1;
 }
 

--- a/stack.c
+++ b/stack.c
@@ -2,20 +2,20 @@
 #include <stdlib.h>
 #include "stack.h"
 
-void stackInit(Stack *s)
+void stackInit(Stack *s, int size)
 {
-	s->content = NULL;
+	s->content = malloc(size * sizeof(void*));
 	s->size = 0;
 	s->top = -1;
 }
 
 void stackPush(Stack *s, void* val)
 {
-	if(s->top + 1 >= s->size) // If stack is full
+	/*if(s->top + 1 >= s->size) // If stack is full
 	{
 		(s->size)++;
 		s->content = (void**)realloc(s->content, s->size * sizeof(void*));
-	}
+	}*/
 
 	(s->top)++;
 	s->content[s->top] = val;
@@ -44,7 +44,8 @@ int stackSize(Stack *s)
 
 void stackFree(Stack *s)
 {
-	free(s->content);
+	if (s->content)
+		free(s->content);
 	s->content = NULL;
 	s->size = 0;
 	s->top = -1;

--- a/stack.h
+++ b/stack.h
@@ -5,7 +5,7 @@ typedef struct
 	int top;
 } Stack;
 
-void stackInit(Stack *s);
+void stackInit(Stack *s, int size);
 void stackPush(Stack *s, void* val);
 void* stackTop(Stack *s);
 void* stackPop(Stack *s);

--- a/stack_test.c
+++ b/stack_test.c
@@ -11,6 +11,7 @@ int main()
 	char* str = NULL;
 	int val = 0;
 	int i;
+	int *iptr;
 
 	stackInit(&strs, STACKSIZE);
 	stackInit(&ints, STACKSIZE);
@@ -58,6 +59,11 @@ int main()
 	for(i = 1; i <= 4; i++)
 	{
 		int *add = (int*)malloc(sizeof(int));
+		if (add == NULL)
+		{
+			printf("Cannot allocate memory, poping stack\n");
+			goto error_pop;
+		}
 		*add = i;
 		printf("Pushing %d\n", *add);
 		stackPush(&ints, add);
@@ -70,9 +76,11 @@ int main()
 		printf("%d\n", *((int*)(ints.content[i])));
 	}
 
-	val = *(int*)stackPop(&ints);
-	printf("stackPop() returned %d\n", val);
+	iptr = (int*)stackPop(&ints);
+	printf("stackPop() returned %d\n", *iptr);
+	free(iptr);
 	printf("Remainder of stack:\n");
+error_pop:
 	while(stackSize(&ints))
 	{
 		int *rem = (int*)stackPop(&ints);

--- a/stack_test.c
+++ b/stack_test.c
@@ -2,6 +2,8 @@
 #include <stdlib.h>
 #include "stack.h"
 
+#define STACKSIZE 100
+
 int main()
 {
 	Stack strs;
@@ -10,8 +12,8 @@ int main()
 	int val = 0;
 	int i;
 
-	stackInit(&strs);
-	stackInit(&ints);
+	stackInit(&strs, STACKSIZE);
+	stackInit(&ints, STACKSIZE);
 
 	// Test strings
 	printf("Test strings:\n");
@@ -80,4 +82,5 @@ int main()
 	}
 
 	stackFree(&ints);
+	return 0;
 }


### PR DESCRIPTION
- Reduce memory footprint: Use a temporary token during parsing and instead of reallocating a new one for every parsing step.
- Remove frequent reallocs: Initialize stack with maximal size
- Remove all memory leaks: All intermediate tokens are stored and freed in the end
- Add support for scientific notation with negative exponent: Tokens like 1E-09 are now recognized properly
- Minor change: Use higher precision
