### PR TITLE
fix memory leak

### DIFF
--- a/calculator.c
+++ b/calculator.c
@@ -993,7 +993,8 @@ bool postfix(token *tokens, int numTokens, Stack *output)
 	// free remaining intermediate results
 	while (stackSize(&intermediate) > 0)
 	{
-		stackPop(&intermediate);
+		token s = stackPop(&intermediate);
+		free(s);
 	}
 	if (err == true)
 	{


### PR DESCRIPTION
I think there will be a memory leak if you don't free what you popped. And I use valgrind to double check this.
![fb0b9d15-c87c-4633-ac5b-2c62f642f316](https://user-images.githubusercontent.com/29591009/50540933-63fde000-0bd6-11e9-8777-50f317934b66.png)
