### PR TITLE
Fix memory leak in case of divide-by-zero

### DIFF
--- a/calculator.c
+++ b/calculator.c
@@ -16,6 +16,14 @@
 #define DEFAULTPRECISION 5
 #define FUNCTIONSEPARATOR "|"
 
+#ifndef NAN
+#define NAN (0.0/0.0)
+#endif
+
+#ifndef INFINITY
+#define INFINITY (1.0/0.0)
+#endif
+
 typedef enum
 {
 	addop,
@@ -302,6 +310,7 @@ token doFunc(Stack *s, token function)
 
 int doOp(Stack *s, token op)
 {
+	int err = 0;
 	token roperand = (token)stackPop(s);
 	token loperand = (token)stackPop(s);
 	number lside = buildNumber(loperand);
@@ -324,7 +333,11 @@ int doOp(Stack *s, token op)
 				if(rside == 0)
 				{
 					raise(divZero);
-					return -1;
+					if (lside == 0)
+						ret = NAN;
+					else
+						ret = INFINITY;
+					err = -1;
 				}
 				else
 					ret = lside / rside;
@@ -335,7 +348,11 @@ int doOp(Stack *s, token op)
 				if(rside == 0)
 				{
 					raise(divZero);
-					return -1;
+					if (lside == 0)
+						ret = NAN;
+					else
+						ret = INFINITY;
+					err = -1;
 				}
 				else
 				{
@@ -356,7 +373,7 @@ int doOp(Stack *s, token op)
 			break;
 	}
 	stackPush(s, num2Str(ret));
-	return 0;
+	return err;
 }
 
 /*


### PR DESCRIPTION
Calculation of 1E-06*(1.0000/0.00000)*64/1.222 results in memory leak/double free. 1.0/0.0 or 0.0/0.0 is not enough to trigger the error, the term must be inside multiple operations.

```
$ ./calc 
1E-06*(1.0000/0.00000)*64/1.2222
	Error: Divide by zero
	Error evaluating expression
=================================================================
==3681==ERROR: AddressSanitizer: attempting double-free on 0x60200000eff0 in thread T0:
    #0 0x7ff80b3db2ca in __interceptor_free (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x982ca)
    #1 0x405e95 in main /home/tom/Work/calc-orig/calculator.c:1351
    #2 0x7ff80ac9082f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
    #3 0x401318 in _start (/home/tom/Work/calc-orig/calc+0x401318)

0x60200000eff0 is located 0 bytes inside of 6-byte region [0x60200000eff0,0x60200000eff6)
freed by thread T0 here:
    #0 0x7ff80b3db2ca in __interceptor_free (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x982ca)
    #1 0x404723 in postfix /home/tom/Work/calc-orig/calculator.c:997
    #2 0x405d00 in main /home/tom/Work/calc-orig/calculator.c:1323
    #3 0x7ff80ac9082f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)

previously allocated by thread T0 here:
    #0 0x7ff80b3db602 in malloc (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x98602)
    #1 0x40397e in tokenize /home/tom/Work/calc-orig/calculator.c:709
    #2 0x405b6c in main /home/tom/Work/calc-orig/calculator.c:1303
    #3 0x7ff80ac9082f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
```