### PR TITLE
Remove double free of new token if realloc of token list fails

### DIFF
--- a/calculator.c
+++ b/calculator.c
@@ -734,7 +734,6 @@ int tokenize(char *str, char *(**tokensRef))
 			tmp = (char**)realloc(tokens, numTokens * sizeof(char*));
 			if (tmp == NULL)
 			{
-				free(newToken);
 				if (tokens != NULL)
 				{
 					for(i=0;i<numTokens-1;i++)


### PR DESCRIPTION
The other free is in line 748:
https://github.com/btmills/calculator/blob/master/calculator.c#L748