### PR TITLE
Extra type check for special numbers 'nan' and 'inf'

### DIFF
--- a/calculator.c
+++ b/calculator.c
@@ -538,6 +538,11 @@ bool isFunction(token tk)
 		|| strncmp(tk, "exp", 3) == 0);
 }
 
+bool isSpecialValue(token tk)
+{
+	return (strncmp(tk, "nan", 3) == 0 || strncmp(tk, "inf", 3) == 0);
+}
+
 Symbol tokenType(token tk)
 {
 	if (!tk)
@@ -548,6 +553,8 @@ Symbol tokenType(token tk)
 		case text:
 			if(isFunction(tk))
 				ret = function;
+			else if(isSpecialValue(tk))
+				ret = value;
 			else
 				ret = identifier;
 			break;


### PR DESCRIPTION
At the moment, the values 'nan' and 'inf' are recognized as type 'text' but they are should be 'value'.

Try with:
`1.0E-6*nan*64.0/0.111`
Is returns 0 and causes a memory leak but should return NAN. This happens because the evaluated tokens will be `1.0E-6`, `*`, `*`, `64.0`, `/` and `0.111`. The second `*` is pushed on the wrong stack because there are less than two values on the output stack.