### PR TITLE
Fix nan in functions

### DIFF
--- a/calculator.c
+++ b/calculator.c
@@ -304,7 +304,7 @@ int doFunc(Stack *s, token function)
 		result /= counter;
 		stackFree(&tmp);
 	}
-	if (strcmp(stackTop(s), FUNCTIONSEPARATOR) == 0)
+	if (stackTop(s) && strcmp(stackTop(s), FUNCTIONSEPARATOR) == 0)
 		stackPop(s);
 	stackPush(s, num2Str(result));
 	return 0;

--- a/calculator.c
+++ b/calculator.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 #include <math.h> // Temporary
 #include <getopt.h>
 #include "stack.h"
@@ -304,7 +305,7 @@ int doFunc(Stack *s, token function)
 		result /= counter;
 		stackFree(&tmp);
 	}
-	if (stackTop(s) && strcmp(stackTop(s), FUNCTIONSEPARATOR) == 0)
+	if (strcmp(stackTop(s), FUNCTIONSEPARATOR) == 0)
 		stackPop(s);
 	stackPush(s, num2Str(result));
 	return 0;
@@ -614,6 +615,7 @@ int tokenize(char *str, char *(**tokensRef))
 							int len = 1;
 							bool hasDecimal = false;
 							bool hasExponent = false;
+							bool isSpecial = isSpecialValue(ptr);
 
 							if(type(ch) == decimal) // Allow numbers to start with decimal
 							{
@@ -637,7 +639,8 @@ int tokenize(char *str, char *(**tokensRef))
 								 		&& hasDecimal == 0)) // But we have not added a decimal
 								 	|| ((*ptr == 'E' || *ptr == 'e') // Or the next character is an exponent
 								 		&& hasExponent == false) // But we have not added an exponent yet
-								|| ((*ptr == '+' || *ptr == '-') && hasExponent == true)); // Exponent with sign
+								|| ((*ptr == '+' || *ptr == '-') && hasExponent == true) // Exponent with sign
+								|| (isSpecial && type(*ptr) == text)); //
 								++len)
 							{
 								if(type(*ptr) == decimal)


### PR DESCRIPTION
The current version does not properly parse special values like `-nan` or `-inf`. It creates two tokens '-' and 'nan' which segfaults if such a negative special value is used in functions. This pull request adds a parsing rule to the tokenizer.

Test with:
`sum(-nan,1)`