### PR TITLE
Lowercase string tokens while tokenizing

### DIFF
--- a/calculator.c
+++ b/calculator.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 #include <math.h> // Temporary
 #include <getopt.h>
 #include "stack.h"
@@ -713,10 +714,10 @@ int tokenize(char *str, char *(**tokensRef))
 				// Assemble an n-character (plus null-terminator) text token
 				{
 					int len = 1;
-					tmpToken[0] = ch;
+					tmpToken[0] = tolower(ch);
 					for(len = 1; *ptr && type(*ptr) == text && len <= prefs.maxtokenlength; ++len)
 					{
-						tmpToken[len] = *ptr++;
+						tmpToken[len] = tolower(*ptr++);
 					}
 					tmpToken[len] = '\0';
 				}


### PR DESCRIPTION
This PR changes all letters to lowercase while parsing. This simplyfies the matching later for special floats (`nan`, `NaN`, ...) and functions (`Sum`, `sum`, `SUM`, ...).
I'm not sure whether this rule is too general and we should delay the case switching. I needs to be done latest before checking the token type and calling `doFunc()`