### PR TITLE
Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,6 @@ stack.o: stack.c stack.h
 	$(CC) $(CFLAGS) stack.c $(LIBS)
 
 clean:
-	rm -f *.o calc stack_test
+	rm -f *.o stack_test
 
 .PHONY: calc


### PR DESCRIPTION
Modified the makefile in regards to the "make clean" command. When "make clean" was originally ran, it would remove the newly compiled binary. The original line would read: "rm -f *.o calc stack_test" so I removed "calc" from that line in the clean file. The new line should read as: "rm -f *.o stack_test"